### PR TITLE
framerate fix

### DIFF
--- a/dpxderiver
+++ b/dpxderiver
@@ -167,6 +167,7 @@ while [ "${*}" != "" ] ; do
     # set input_options for transcoding
     input_options+=(-v warning)
     input_options+=(-stats)
+    input_options+=(-framerate ${input_frame_rate})
     input_options+=(-start_number ${start_number})
     if [ "${overwrite_outputs}" ] ; then
         input_options+=(-"${overwrite_outputs}")


### PR DESCRIPTION
tested on El Capitan using 12 and 18fps - both result in the correct framerate being carried over to the output file. Here's an example of an output where 12fps was chosen.

```
ifi-mac-pro:~ admin$ ffmpeg -i /Users/admin/dpxooooo/lossless/dpxooooo.mov 
ffmpeg version N-43982-g16ea0bc Copyright (c) 2000-2016 the FFmpeg developers
  built with Apple LLVM version 7.3.0 (clang-703.0.31)
  configuration: --prefix=/usr/local/Cellar/ffmpeg/HEAD --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-opencl --enable-libx264 --enable-libmp3lame --enable-libxvid --enable-libfreetype --enable-ffplay --disable-lzma --enable-libopenjpeg --disable-decoder=jpeg2000 --extra-cflags=-I/usr/local/Cellar/openjpeg/1.5.2_1/include/openjpeg-1.5 --enable-vda
  libavutil      55. 28.100 / 55. 28.100
  libavcodec     57. 51.100 / 57. 53.100
  libavformat    57. 46.100 / 57. 46.101
  libavdevice    57.  0.102 / 57.  0.102
  libavfilter     6. 50.100 /  6. 52.100
  libavresample   3.  0.  0 /  3.  0.  0
  libswscale      4.  1.100 /  4.  1.100
  libswresample   2.  1.100 /  2.  1.100
  libpostproc    54.  0.100 / 54.  0.100
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '/Users/admin/dpxooooo/lossless/dpxooooo.mov':
  Metadata:
    major_brand     : qt  
    minor_version   : 512
    compatible_brands: qt  
    encoder         : Lavf57.46.101
  Duration: 00:00:20.00, start: 0.000000, bitrate: 1296 kb/s
    Stream #0:0(eng): Video: h264 (High 4:4:4 Predictive) (avc1 / 0x31637661), yuv422p, 1920x1080 [SAR 1:1 DAR 16:9], 142 kb/s, 12 fps, 12 tbr, 12288 tbn, 24 tbc (default)
    Metadata:
      handler_name    : DataHandler
      encoder         : Lavc57.51.100 libx264
    Stream #0:1(eng): Audio: pcm_s24le (in24 / 0x34326E69), 48000 Hz, stereo, s32 (24 bit), 2304 kb/s (default)
    Metadata:
      handler_name    : DataHandler

```
